### PR TITLE
update and fix CMakeLists.txt to include boost lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,7 @@ project(Syft)
 
 set (CMAKE_CXX_STANDARD 14)
 set (CMAKE_BUILD_TYPE Debug)
-
-add_compile_options(-std=c++14)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
 
 set(CMAKE_MODULE_PATH
     "${CMAKE_MODULE_PATH}"
@@ -13,9 +12,14 @@ set(CMAKE_MODULE_PATH
   
 set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin )
 set( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib )
-  
+
 find_package(cudd REQUIRED)
 find_package(BISON REQUIRED)
 find_package(FLEX REQUIRED)
+find_package(Boost)
+if (Boost_FOUND)
+    include_directories(${Boost_INCLUDE_DIR})
+    add_definitions( "-DHAS_BOOST" )
+endif()
 
 add_subdirectory(src)


### PR DESCRIPTION
Hi Shufang,

while installing Syft locally, I found that there were the following two little problems:
- CMAKE_CXX_FLAGS not set properly
- The Boost library was not included

So, I fixed them updating the CMakeLists.txt. 
Cheers, Francesco